### PR TITLE
replaced Double with Log Double where appropriate

### DIFF
--- a/Control/Monad/Bayes/Interface.idr
+++ b/Control/Monad/Bayes/Interface.idr
@@ -14,6 +14,8 @@ import public Statistics.Distribution.Uniform
 import public Statistics.Distribution.Normal
 --import Statistics.Distribution.Binomial
 
+import Numeric.Log
+
 -- TODO: implement more distributions
 public export
 interface Monad m => MonadSample m where
@@ -42,7 +44,7 @@ interface Monad m => MonadSample m where
 public export
 interface Monad m => MonadCond m where
   ||| Record a likelihood
-  score : Double -> m ()  -- TODO: replace with Log Double
+  score : Log Double -> m ()  
 
 export
 condition : MonadCond m => Bool -> m ()

--- a/Control/Monad/Bayes/Traced/Common.idr
+++ b/Control/Monad/Bayes/Traced/Common.idr
@@ -1,5 +1,7 @@
 module Control.Monad.Bayes.Traced.Common
 
+import Numeric.Log
+
 record Trace (a : Type) where
   constructor MkTrace 
   -- | Sequence of random variables sampled during the program's execution.
@@ -7,7 +9,7 @@ record Trace (a : Type) where
   -- |
   output    : a
   -- | The probability of observing this particular sequence.
-  density   : Double      -- TODO: replace Double with Log Double
+  density   : Log Double     
 
 Functor Trace where
   map f t = { output $= f } t
@@ -29,7 +31,7 @@ Monad Trace where
 singleton : Double -> Trace Double
 singleton u = MkTrace {variables = [u], output = u, density = 1}
 
-scored : Double -- TODO: replace Double with Log Double
+scored : Log Double
       -> Trace ()
 scored w = MkTrace {variables = [], output = (), density = w}
 

--- a/Control/Monad/Bayes/Weighted.idr
+++ b/Control/Monad/Bayes/Weighted.idr
@@ -7,10 +7,12 @@ import Control.Monad.State
 
 import Control.Monad.Bayes.Interface
 
+import Numeric.Log
+
 ||| Execute the program using the prior distribution, while accumulating likelihood.
 public export
 Weighted : (m : Type -> Type) -> (a : Type) -> Type
-Weighted = StateT Double  -- TODO: replace Double with Log Double
+Weighted = StateT (Log Double)  -- TODO: replace Double with Log Double
 
 export
 MonadSample m => MonadSample (Weighted m) where
@@ -25,7 +27,7 @@ MonadSample m => MonadInfer (Weighted m) where
 
 ||| Obtain an explicit value of the likelihood for a given value
 export
-runWeighted : Weighted m a -> m (Double, a)
+runWeighted : Weighted m a -> m (Log Double, a)
 runWeighted = runStateT 1
 
 ||| Compute the sample and discard the weight.
@@ -36,12 +38,12 @@ prior = map snd . runWeighted
 
 ||| Compute the weight and discard the sample.
 export
-extractWeight : Functor m => Weighted m a -> m Double
+extractWeight : Functor m => Weighted m a -> m (Log Double)
 extractWeight = map fst . runWeighted
 
 ||| Embed a random variable with explicitly given likelihood
 export
-withWeight : Monad m => m (Double, a) -> Weighted m a
+withWeight : Monad m => m (Log Double, a) -> Weighted m a
 withWeight m = do
   (w, x) <- lift m
   get >>= (put . (w *))

--- a/idris-monad-bayes.ipkg
+++ b/idris-monad-bayes.ipkg
@@ -1,6 +1,6 @@
 package idris-monad-bayes
 
-depends = contrib, free, distributions
+depends = contrib, free, distributions, log-domain
 
 modules = Control.Monad.Bayes.Interface
         , Control.Monad.Bayes.Free


### PR DESCRIPTION
Added `log-domain`, so we can have `Log Double` instead of `Double` now.

Add this to `~/.pack/user/pack.toml`:
```
[custom.all.log-domain]
type   = "github"
url    = "https://github.com/idris-bayes/log-domain"
commit = "latest:master"
ipkg   = "log-domain.ipkg"
```