### PR TITLE
Fix errors due to changes in positivity checking

### DIFF
--- a/Control/Monad/Bayes/Inference/SMC2.idr
+++ b/Control/Monad/Bayes/Inference/SMC2.idr
@@ -12,18 +12,18 @@ import Numeric.Log
 export
 record SMC2 (m : Type -> Type) (a : Type) where
   constructor MkSMC2
-  setup : Sequential (Traced (Population m)) a 
+  setup : Sequential (Traced (Population m)) a
 
 export
 Monad m => Functor (SMC2 m) where
-  map f (MkSMC2 mx) = MkSMC2 (map f mx) 
+  map f (MkSMC2 mx) = MkSMC2 (map f mx)
 
 export
 Monad m => Applicative (SMC2 m) where
-  pure = MkSMC2 . pure 
+  pure = MkSMC2 . pure
   (MkSMC2 mf) <*> (MkSMC2 ma) = MkSMC2 (mf <*> ma)
 
-export
+export covering
 Monad m => Monad (SMC2 m) where
   (MkSMC2 mx) >>= k = MkSMC2 ((assert_total (>>=)) mx (setup . k))
 
@@ -37,7 +37,7 @@ MonadSample m => MonadSample (SMC2 m) where
 
 export
 Monad m => MonadCond (SMC2 m) where
-  score w = MkSMC2 $ score w 
+  score w = MkSMC2 $ score w
 
 export
 MonadSample m => MonadInfer (SMC2 m) where
@@ -60,5 +60,5 @@ smc2 :
   (b -> Sequential (Population (SMC2 m)) a) ->
   Population m (List (Log Double, a))
 smc2 n_timesteps n_inner_particles n_outer_particles n_mhsteps param model =
-  rmsmc n_timesteps n_outer_particles n_mhsteps 
+  rmsmc n_timesteps n_outer_particles n_mhsteps
     (param >>= setup . runPopulation . smcSystematicPush n_timesteps n_inner_particles . model)

--- a/Control/Monad/Bayes/Sequential.idr
+++ b/Control/Monad/Bayes/Sequential.idr
@@ -2,25 +2,25 @@ module Control.Monad.Bayes.Sequential
 
 import Control.Monad.Trans
 import Control.Monad.Bayes.Interface
- 
+
 ||| Represents a computation that can be suspended at certain points.
 -- The intermediate monadic effects can be extracted, which is particularly
 -- useful for implementation of Sequential Monte Carlo related methods.
 -- All the probabilistic effects are lifted from the transformed monad, but
 -- also `suspend` is inserted after each `score`.
 export
-data Sequential : (m : Type -> Type) -> (a : Type) -> Type where 
+data Sequential : (m : Type -> Type) -> (a : Type) -> Type where
   MkSeq : Inf (m (Either a (Sequential m a))) -> Sequential m a
 
 export
 runSeq : Sequential m a -> m (Either a (Sequential m a))
 runSeq (MkSeq m) = m
 
-mutual 
+mutual
   export
   Monad m => Functor (Sequential m) where
     map f (MkSeq mx) = MkSeq (do
-      x <- mx 
+      x <- mx
       case x of Left l  => pure (Left $ f l)
                 Right r => pure (Right $ map f r))
   export
@@ -31,12 +31,12 @@ mutual
       v' <- mv
       pure $ f' v'
 
-  export
+  export covering
   Monad m => Monad (Sequential m) where
     (>>=) (MkSeq mx) f = MkSeq $ do
       x <- mx
       case x of
-        Left l    => runSeq (f l) 
+        Left l    => runSeq (f l)
         Right seq => pure (Right ((assert_total (>>=)) seq  f))
 
   export


### PR DESCRIPTION
Hello, I wanted to try this library but it wasn't compiling on the latest version of the compiler due to changes in the positivity checking. I've quickly fixed the compiler errors by declaring Monad implementation as covering rather than total. 

Also my editor automatically removes extra whitespace, so there is a bit of noise in the diff, sorry about that.